### PR TITLE
use Kernel#puts for 1.8 support

### DIFF
--- a/check_graphite
+++ b/check_graphite
@@ -12,7 +12,7 @@ EXIT_UNKNOWN = 3
 @@options = {}
 
 optparse = OptionParser.new do |opts|
-  opts.banner = "Usage: check_graphite.rb [options]"
+  opts.banner = "Usage: #{File.basename($0)} [options]"
 
   @@options[:url] = nil
   opts.on("-u", "--url URL", "Target url") do |url|


### PR DESCRIPTION
also checks for the script's basename (check_graphite.rb isn't the correct name now, and might change in future).
