### PR TITLE
Fix potential division-by-zero, add optional perfdata via --shortname option

### DIFF
--- a/check_graphite
+++ b/check_graphite
@@ -71,6 +71,9 @@ JSON.parse(RestClient.get(url)).each do |cache|
       count += 1
     end
   end
+  if (count == 0)
+    count = 1
+  end
   data["#{cache['target']}"] /= count
   data["total"] += data["#{cache['target']}"]
 end


### PR DESCRIPTION
Hi,

this one fixes a potential division by zero error. The commit before that one adds a "--shortname" option which can be used to output simple performance data.

In my perfdata branch HEAD there's also a "check_graphite_multi" version which allows to pull multiple metrics from graphite at once, including perfdata. I use it to get various metrics from graphite into Centreon 2.4 at once. It's sort of a "Graphite is a bitch" approach of integrating it into Centreon...

```
./check_graphite_multi -u http://graphite.planethome.com -m 'scale(stats.timers.logstash.prod.weblogic.server01.memory.gc_total_time.upper,1000)|scale(stats.timers.logstash.prod.weblogic.server08.memory.gc_total_time.upper,1000)' -w 10,50 -c 100,200 -s gctime_server01,gctime_server08
WARNING - gctime_server01: 32, gctime_server08: 26 | gctime_server01=32;10;100; gctime_server08=26;50;200;
```

Feel free to cherry pick or anything. Thanks a lot for your (initial) plugin, it helped a lot!
