### PR TITLE
Enable functions in graphite values

### DIFF
--- a/check_graphite
+++ b/check_graphite
@@ -66,7 +66,7 @@ end
 data = {}
 data["total"] = 0
 
-JSON.parse(RestClient.get(url)).each do |cache|
+JSON.parse(RestClient.get(URI.encode(url))).each do |cache|
   data["#{cache['target']}"] = 0
   count = 0
   cache["datapoints"].each do |point|


### PR DESCRIPTION
this small fix, means I can use arguments like 'sumSeries(server1.counter, server2.counter)' - to get the sum of counters for two servers f.ex. :)

I also use this, for alerting on varnish hitrates (by using asPercent - and calculating the hitrate).
