### PR TITLE
When warning and critical thresholds are equal, don't go critical on stats that are less than the critical threshold.

### DIFF
--- a/check_graphite
+++ b/check_graphite
@@ -88,7 +88,7 @@ total = data["total"].to_i
 perfdata = ""
 perfdata = "| #{@@options[:shortname]}=#{total}" if !@@options[:shortname].nil?
 
-if (@@options[:critical].to_i > @@options[:warning].to_i)
+if (@@options[:critical].to_i >= @@options[:warning].to_i)
   if (total >= @@options[:critical].to_i)
     puts "CRITICAL metric count: #{total} #{perfdata}"
     exit EXIT_CRITICAL


### PR DESCRIPTION
We have a dead letter queue that we want to be alerted on if any message is sent there. Setting warning/critical both to 1 caused a 0 from graphite to go critical in nagios.
