### PR TITLE
check_graphite error handling

### DIFF
--- a/check_graphite
+++ b/check_graphite
@@ -70,22 +70,31 @@ end
 data = {}
 data["total"] = 0
 
-JSON.parse(RestClient.get(URI.encode(url))).each do |cache|
-  data["#{cache['target']}"] = 0
-  count = 0
-  cache["datapoints"].each do |point|
-    unless (point[0].nil?)
-      data["#{cache['target']}"] += point[0]
-      count += 1
+begin
+  JSON.parse(RestClient.get(URI.encode(url))).each do |cache|
+    data["#{cache['target']}"] = 0
+    count = 0
+    cache["datapoints"].each do |point|
+      unless (point[0].nil?)
+        data["#{cache['target']}"] += point[0]
+        count += 1
+      end
     end
+    if (count == 0)
+      count = 1
+    end
+    if (@@options[:function] == "average")
+      data["#{cache['target']}"] /= count  
+    end
+    data["total"] += data["#{cache['target']}"]
   end
-  if (count == 0)
-    count = 1
+rescue RestClient::InternalServerError
+  if @@options[:zero_on_error]
+    data["total"] = 0
+  else
+    puts "CRITICAL 500 error from Graphite"
+    exit EXIT_CRITICAL
   end
-  if (@@options[:function] == "average")
-    data["#{cache['target']}"] /= count  
-  end
-  data["total"] += data["#{cache['target']}"]
 end
 
 total = data["total"].to_i


### PR DESCRIPTION
If a 500 error is returned from graphite, the current script will throw an unhandled exception, resulting in Nagios going CRITICAL with a description of "(null)".

This patch will catch that exception, and will also exit CRITICAL, but will exit with a string of "CRITICAL 500 error from Graphite" to aid the admin in tracking the issue.

The patch also adds a --zero-on-error option (also -z) that will treat a 500 error as a metric value of 0, and continue on.  

The default behavior is to exit CRITICAL unless -z is specified.

Our use case for this is where collectd is sending swap metrics to graphite.  We are migrating to systems that do not have any swap, so for new hosts, there are no swap metrics.  When graphite sends a 500 error because that metric doesn't exist, we don't want that to be a CRITICAL state.
