### PR TITLE
Adding the option to put a tag to the metric count stating the units. 

### DIFF
--- a/check_graphite
+++ b/check_graphite
@@ -44,7 +44,7 @@ optparse = OptionParser.new do |opts|
     @@options[:critical] = critical
   end
   @@options[:units] = nil
-  opts.on("-U", "--units VALUE", "Units for the metric") do |units|
+  opts.on("-U", "--units VALUE", "Adds a text tag to the metric count in the plugin output. Useful to identify the metric units. Doesn't affect data queries.") do |units|
     @@options[:units] = units
   end
   @@options[:zero_on_error] = false


### PR DESCRIPTION
Sometimes you get an alert saying 'alert, metric is at 5' and you think 'ok, but 5 what???'. Sometimes it's helpful to know if the metric is GB or MB, or GB or Gb. This simple change allows you to optionally set this tag.
