### PR TITLE
Units missing in status OK

### DIFF
--- a/check_graphite
+++ b/check_graphite
@@ -124,7 +124,7 @@ else
     puts "WARNING metric count: #{total}#{@@options[:units]} threshold: #{@@options[:warning]} #{perfdata}"
     exit EXIT_WARNING
   else
-    puts "OK metric count: #{total} #{perfdata}"
+    puts "OK metric count: #{total}#{@@options[:units]} #{perfdata}"
     exit EXIT_OK
   end
 end


### PR DESCRIPTION
I added units to status CRITICAL and status WARNING, but forgot to add them to status OK.

Sorry, I just spotted it.
