### PR TITLE
Adds the possibility of using a custom message for each nagios check.

### DIFF
--- a/check_graphite
+++ b/check_graphite
@@ -117,7 +117,7 @@ if (@@options[:critical].to_i > @@options[:warning].to_i)
     puts "WARNING #{@@options[:message]} #{total}#{@@options[:units]} threshold: #{@@options[:warning]} #{perfdata}"
     exit EXIT_WARNING
   else
-    puts "OK metric count: #{total} #{perfdata}"
+    puts "OK #{@@options[:message]} #{total}#{@@options[:units]} #{perfdata}"
     exit EXIT_OK
   end
 else


### PR DESCRIPTION
This way nagios alerts can contain useful info, being more self-explanatory and easy to fix.

It's just aesthetic, but helps a lot.

Before I had:
WARNING metric count: 9

Now I have:
WARNING Free disk in root partition: 9% threshold: 10

I'm very happy with the change :)
