### PR TITLE
Add the option to include a link to data in plugin output

### DIFF
--- a/check_graphite
+++ b/check_graphite
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby1.9.3
+#!/usr/bin/env ruby
 
 require "rubygems"
 require "optparse"


### PR DESCRIPTION
When you get an alert in nagios, and you are not familiar with the environment, it's very helpful to have some background. If you can see some history of the metric you'll have more information about the gravity of the situation, and what behaviour had the metric before reaching the threshold.

I've chosen 24h of history. This could be configurable, of course, but I didn't want to add too much options to the script. 24h seemed a sane default value.

Same thing about the size of the graph. I've chosen 700x450 and that should fit any screen size and resolution. But it can be configurable, as well. Just trying to keep it simple.

Finally, I've tried to make a lateral line marking the threshold in graphite, I think it's a good idea. But something happens in graphite's constantLine function, I think it's broken (I opened a issue https://github.com/graphite-project/graphite-web/issues/625), so that can be added in the future, when constantLine works again.
