### PR TITLE
Introducing threshold lines in nagios graphs

### DIFF
--- a/check_graphite
+++ b/check_graphite
@@ -83,7 +83,7 @@ def output_url
   base_url = @@options[:url]
   metric = @@options[:metric]
   if @@options[:link_graph]  
-    "<a href=\"http://" + base_url + "/render/?target=" + URI.escape(metric) + "&from=-24h&width=700&height=450\"> 24h graph </a>"
+    "<a href=\"http://" + base_url + URI.escape("/render/?target=" + @@options[:metric] + "&from=-24h&width=700&height=450&target=threshold(#{@@options[:warning]},\"warning\",\"yellow\")&target=threshold(#{@@options[:critical]},\"critical\",\"red\")") + "\"> 24h graph </a>"
   end
 end  
 


### PR DESCRIPTION
In our nagios graph now we're having a yellow line for our "warning" thresholds and a red one for "critical", so you know graphically how far from the thresholds you are. And it's being pretty useful :)

Example:
![nagios-graph-with-thresholds](https://f.cloud.github.com/assets/5192538/2339463/14f17a94-a4b6-11e3-9de3-158c22b3b103.png)
